### PR TITLE
Update exit hook

### DIFF
--- a/hook.sh
+++ b/hook.sh
@@ -153,6 +153,10 @@ function find_zone() {
   return 1
 }
 
+function exit_hook() {
+  exit 0
+}
+
 HANDLER="$1"; shift
 if [[ "${HANDLER}" =~ ^(deploy_challenge|clean_challenge|deploy_cert|unchanged_cert|invalid_challenge|request_failure|exit_hook)$ ]]; then
   "$HANDLER" "$@"

--- a/hook.sh
+++ b/hook.sh
@@ -154,4 +154,6 @@ function find_zone() {
 }
 
 HANDLER="$1"; shift
-"$HANDLER" "$@"
+if [[ "${HANDLER}" =~ ^(deploy_challenge|clean_challenge|deploy_cert|unchanged_cert|invalid_challenge|request_failure|exit_hook)$ ]]; then
+  "$HANDLER" "$@"
+fi


### PR DESCRIPTION
This fixes the error
`exit_hook: command not found`