### PR TITLE
corrected sample IAM policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ You can and should create an AWS IAM user, and attach just the minimum policy ne
             "Effect": "Allow",
             "Action": [
                 "route53:ListHostedZones",
-                "route53:ListHostedZonesByName"
+                "route53:ListHostedZonesByName",
+                "route53:ListResourceRecordSets"
             ],
             "Resource": "*"
         },


### PR DESCRIPTION
The sample IAM policy doesn't have sufficient privileges to properly execute - when using it i was getting an error:
```
dehydrated@localhost:~$ ./dehydrated --cron --accept-terms
# INFO: Using main config file /home/dehydrated/config
Processing xx.yy.net
 + Signing domains...
 + Generating private key...
 + Generating signing request...
 + Requesting challenge for ubnt.cynexia.net...
Error: AccessDenied: User: arn:aws:iam::598131871882:user/dehydrated-on-xx-yy-net is not authorized to perform: route53:ListHostedZones
        status code: 403, request id: 18afbe49-6945-11e7-b922-81395483c5d6
Could not find zone for xx.yy.net
```

After adding ```"route53:ListResourceRecordSets"``` to the initial access group it works.