### PR TITLE
Corrected example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The script requires the following tools, all of which should be in your Linux di
 This script will only work if `dehydrated` if using the following `config` settings.
 ```
 CHALLENGETYPE="dns-01"
-HOOK=hook.sh
+HOOK="./hook.sh"
 HOOK_CHAIN="no"
 ```
 


### PR DESCRIPTION
After running dehydrated I got the following errors:

```
./dehydrated: line 90: hook.sh: command not found
ERROR: Please check your hook script, it should exit cleanly without doing anything on unknown/new hooks.
./dehydrated: line 450: hook.sh: command not found
exit_hook returned with non-zero exit code!
```

It seems that in the configuration it is necessary to set `./hook.sh` instead of `hook.sh`, like when running a script from terminal.
